### PR TITLE
Added an example for embedding a UIKit view controller in a SwiftUI view.

### DIFF
--- a/ProxyRelease.xcodeproj/project.pbxproj
+++ b/ProxyRelease.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17772D7B274CF51E0034D7CF /* FallbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17772D7A274CF51E0034D7CF /* FallbackViewController.swift */; };
+		17772D7D274CF5E70034D7CF /* FallbackViewControllerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17772D7C274CF5E70034D7CF /* FallbackViewControllerWrapper.swift */; };
+		17772D7F274CF6450034D7CF /* EmbeddingUIKitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17772D7E274CF6450034D7CF /* EmbeddingUIKitView.swift */; };
 		5248C4ED27479BAE007203DB /* ProxyReleaseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248C4EC27479BAE007203DB /* ProxyReleaseApp.swift */; };
 		5248C4EF27479BAE007203DB /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5248C4EE27479BAE007203DB /* RootView.swift */; };
 		5248C4F127479BB0007203DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5248C4F027479BB0007203DB /* Assets.xcassets */; };
@@ -32,6 +35,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		17772D7A274CF51E0034D7CF /* FallbackViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FallbackViewController.swift; sourceTree = "<group>"; };
+		17772D7C274CF5E70034D7CF /* FallbackViewControllerWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FallbackViewControllerWrapper.swift; sourceTree = "<group>"; };
+		17772D7E274CF6450034D7CF /* EmbeddingUIKitView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EmbeddingUIKitView.swift; sourceTree = "<group>"; };
 		5248C4E927479BAE007203DB /* ProxyRelease.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ProxyRelease.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5248C4EC27479BAE007203DB /* ProxyReleaseApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProxyReleaseApp.swift; sourceTree = "<group>"; };
 		5248C4EE27479BAE007203DB /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
@@ -66,6 +72,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		17772D79274CF51E0034D7CF /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				17772D7A274CF51E0034D7CF /* FallbackViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
 		5248C4E027479BAD007203DB = {
 			isa = PBXGroup;
 			children = (
@@ -87,6 +101,7 @@
 		5248C4EB27479BAE007203DB /* ProxyRelease */ = {
 			isa = PBXGroup;
 			children = (
+				17772D79274CF51E0034D7CF /* ViewControllers */,
 				528D97762747B32900C6E2A2 /* Views */,
 				5248C51B2747A17B007203DB /* Model */,
 				5248C4EC27479BAE007203DB /* ProxyReleaseApp.swift */,
@@ -94,6 +109,7 @@
 				52B256F12747A3E700F3EC1B /* RepositoryView.swift */,
 				5248C51827479F49007203DB /* PendingTasksView.swift */,
 				5248C4EE27479BAE007203DB /* RootView.swift */,
+				17772D7E274CF6450034D7CF /* EmbeddingUIKitView.swift */,
 				5248C4F027479BB0007203DB /* Assets.xcassets */,
 				5248C4F227479BB0007203DB /* Preview Content */,
 			);
@@ -128,6 +144,7 @@
 		528D97762747B32900C6E2A2 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				17772D7C274CF5E70034D7CF /* FallbackViewControllerWrapper.swift */,
 				528D97772747B34400C6E2A2 /* SingleLineView.swift */,
 			);
 			path = Views;
@@ -239,10 +256,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				17772D7D274CF5E70034D7CF /* FallbackViewControllerWrapper.swift in Sources */,
 				5248C51727479EE0007203DB /* HomeView.swift in Sources */,
 				5248C51D2747A183007203DB /* Repository.swift in Sources */,
 				52B256F22747A3E700F3EC1B /* RepositoryView.swift in Sources */,
 				5248C4EF27479BAE007203DB /* RootView.swift in Sources */,
+				17772D7B274CF51E0034D7CF /* FallbackViewController.swift in Sources */,
+				17772D7F274CF6450034D7CF /* EmbeddingUIKitView.swift in Sources */,
 				528D97782747B34400C6E2A2 /* SingleLineView.swift in Sources */,
 				5248C51927479F49007203DB /* PendingTasksView.swift in Sources */,
 				52B256F42747A4BD00F3EC1B /* Build.swift in Sources */,

--- a/ProxyRelease/EmbeddingUIKitView.swift
+++ b/ProxyRelease/EmbeddingUIKitView.swift
@@ -1,0 +1,79 @@
+//
+//  EmbeddingUIKitView.swift
+//  TwinPrototyping
+//
+//  Created by Raluca Toadere on 18.11.2021.
+//
+
+import SwiftUI
+import Combine
+
+final class EmbeddingUIKitViewModel: ObservableObject {
+    @Published var title: String
+    @Published var fallbackUIModel: FallbackView.UIModel
+
+    @Published var buttonTapCount: Int = 0
+
+    var timerSubscription: AnyCancellable?
+
+    private var timerFiredCount = 0 {
+        didSet {
+            updateTimerFiredCountBasedValues()
+        }
+    }
+
+    init() {
+        title = Self.buildTitle(timerFiredCount: timerFiredCount)
+        fallbackUIModel = Self.buildFallbackUIModel(timerFiredCount: timerFiredCount)
+        setupBindings()
+    }
+
+    func setupBindings() {
+        timerSubscription = Timer.publish(every: 4, on: .main, in: .default)
+            .autoconnect()
+            .sink(receiveValue: { [weak self] date in
+                guard let self = self else { return }
+                self.timerFiredCount += 1
+            })
+    }
+
+    private func updateTimerFiredCountBasedValues() {
+        self.title = Self.buildTitle(timerFiredCount: timerFiredCount)
+        self.fallbackUIModel = Self.buildFallbackUIModel(timerFiredCount: timerFiredCount)
+    }
+
+    private static func buildTitle(timerFiredCount: Int) -> String {
+        "(SwiftUI) Timer fired \(timerFiredCount) times"
+    }
+
+    private static func buildFallbackUIModel(timerFiredCount: Int) -> FallbackView.UIModel {
+        FallbackView.UIModel(
+            title: "(UIKit) Timer fired \(timerFiredCount) times",
+            actionTitle: "(UIKit) Button")
+    }
+}
+
+struct EmbeddingUIKitView: View {
+    @ObservedObject var viewModel: EmbeddingUIKitViewModel
+    
+    var body: some View {
+        VStack{
+            Text(viewModel.title)
+                .padding()
+            Text("(SwiftUI) Button tap count: \(viewModel.buttonTapCount)")
+                .padding()
+            FallbackViewControllerWrapper(
+                model: $viewModel.fallbackUIModel,
+                buttonTapCount: $viewModel.buttonTapCount
+            )
+        }
+    }
+}
+
+struct EmbeddingUIKitView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            EmbeddingUIKitView(viewModel: EmbeddingUIKitViewModel())
+        }
+    }
+}

--- a/ProxyRelease/PendingTasksView.swift
+++ b/ProxyRelease/PendingTasksView.swift
@@ -14,10 +14,11 @@ struct PendingTasksView: View {
             Section("Exploration") {
                 SingleLineView(title: "Navigation")
                 SingleLineView(title: "Dependency Injection")
-                SingleLineView(title: "Mix SwiftUI & UIKit")
-                SingleLineView(title: "UIKit embebed")
+                NavigationLink(destination: EmbeddingUIKitView(viewModel: EmbeddingUIKitViewModel())) {
+                    SingleLineView(title: "UIKit View Controller Embedded")
+                }
             }
-            
+
             Section("App tasks") {
                 SingleLineView(title: "Trigger builds")
                 SingleLineView(title: "App Icon")

--- a/ProxyRelease/ViewControllers/FallbackViewController.swift
+++ b/ProxyRelease/ViewControllers/FallbackViewController.swift
@@ -1,0 +1,67 @@
+//
+//  FallbackViewController.swift
+//  ProxyRelease
+//
+//  Created by Raluca Toadere on 19.11.2021.
+//
+
+import Foundation
+import UIKit
+
+protocol FallbackViewControllerDelegate {
+    func didTapButton()
+}
+
+class FallbackViewController: UIViewController {
+    var fallbackView: FallbackView?
+    var delegate: FallbackViewControllerDelegate?
+
+    override func loadView() {
+        fallbackView = FallbackView()
+        self.view = fallbackView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        fallbackView?.button.addTarget(self, action: #selector(didTapButton(_:)), for: .touchUpInside)
+    }
+
+    @objc func didTapButton(_ sender: UIButton) {
+        delegate?.didTapButton()
+    }
+}
+
+class FallbackView: UIView {
+
+    struct UIModel {
+        let title: String
+        let actionTitle: String
+    }
+
+    let label = UILabel()
+    let button = UIButton(configuration: .filled(), primaryAction: nil)
+
+    init() {
+        super.init(frame: .zero)
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(label)
+        label.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        label.centerYAnchor.constraint(equalTo: centerYAnchor).isActive = true
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(button)
+        button.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
+        button.topAnchor.constraint(equalTo: label.bottomAnchor, constant: 20).isActive = true
+    }
+
+    func setup(with model: UIModel) {
+        label.text = model.title
+        button.setTitle(model.actionTitle, for: .normal)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/ProxyRelease/Views/FallbackViewControllerWrapper.swift
+++ b/ProxyRelease/Views/FallbackViewControllerWrapper.swift
@@ -1,0 +1,42 @@
+//
+//  FallbackViewControllerWrapper.swift
+//  ProxyRelease
+//
+//  Created by Raluca Toadere on 19.11.2021.
+//
+
+import Foundation
+import SwiftUI
+
+struct FallbackViewControllerWrapper: UIViewControllerRepresentable {
+    @Binding var model: FallbackView.UIModel
+    @Binding var buttonTapCount: Int
+
+    func makeUIViewController(context: Context) -> FallbackViewController {
+        let viewController = FallbackViewController()
+        viewController.delegate = context.coordinator
+        return viewController
+    }
+
+    // communication from SwiftUI to UIKit
+    func updateUIViewController(_ uiViewController: FallbackViewController, context: Context) {
+        uiViewController.fallbackView?.setup(with: $model.wrappedValue)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    // communication from UIKit to SwiftUI
+    class Coordinator: FallbackViewControllerDelegate {
+        let parent: FallbackViewControllerWrapper
+
+        init(_ parent: FallbackViewControllerWrapper) {
+            self.parent = parent
+        }
+
+        func didTapButton() {
+            parent.buttonTapCount += 1
+        }
+    }
+}


### PR DESCRIPTION
This example shows how a UIKit view controller can be embedded in a SwiftUI view alongside other SwiftUI views. The example covers:
- how the view controller can be updated based on changes coming from SwiftUI (specifically the view model driving the entire view)
- how events can be transmitted from the view controller to the SwiftUI embedding view